### PR TITLE
Fix angles in bindings (drawArc and drawSector)

### DIFF
--- a/firefly/bindings.go
+++ b/firefly/bindings.go
@@ -35,7 +35,7 @@ func drawTriangle(x1, y1, x2, y2, x3, y3, fc, sc, sw int32)
 func drawArc(x, y, d int32, ast, asw float32, fc, sc, sw int32)
 
 //go:wasmimport graphics draw_sector
-func drawSector(x, y, d, ast, asw, fc, sc, sw int32)
+func drawSector(x, y, d int32, ast, asw float32, fc, sc, sw int32)
 
 //go:wasmimport graphics draw_text
 func drawText(

--- a/firefly/bindings.go
+++ b/firefly/bindings.go
@@ -32,7 +32,7 @@ func drawEllipse(x, y, w, h, fc, sc, sw int32)
 func drawTriangle(x1, y1, x2, y2, x3, y3, fc, sc, sw int32)
 
 //go:wasmimport graphics draw_arc
-func drawArc(x, y, d, ast, asw, fc, sc, sw int32)
+func drawArc(x, y, d int32, ast, asw float32, fc, sc, sw int32)
 
 //go:wasmimport graphics draw_sector
 func drawSector(x, y, d, ast, asw, fc, sc, sw int32)


### PR DESCRIPTION
`drawArc` expects parameters `ast` (angle-start) and `asw` (angle-sweep), to be of type `float32` instead of `int32`.

Update:
Same for `drawSector`