### PR TITLE
Add 'Vec2' utility type

### DIFF
--- a/firefly/graphics.go
+++ b/firefly/graphics.go
@@ -3,6 +3,8 @@ package firefly
 import (
 	"math"
 	"unsafe"
+
+	"github.com/orsinium-labs/tinymath"
 )
 
 const (
@@ -31,14 +33,19 @@ func (p Point) Draw(c Color) {
 	DrawPoint(p, c)
 }
 
-// Convert the Point to a Size.
+// Convert the Point to a [Size].
 func (p Point) Size() Size {
 	return Size{W: p.X, H: p.Y}
 }
 
-// Convert the Point to a Pad.
+// Convert the Point to a [Pad].
 func (p Point) Pad() Pad {
 	return Pad(p)
+}
+
+// Convert the Point to a [Vec2].
+func (p Point) Vec2() Vec2 {
+	return Vec2{X: float32(p.X), Y: float32(p.Y)}
 }
 
 // Set X and Y to their absolute (non-negative) value.
@@ -193,6 +200,14 @@ func (a Angle) Degrees() float32 {
 	return 180 * a.a / math.Pi
 }
 
+// Convert an Angle to a [Vec2].
+func (a Angle) Vec2() Vec2 {
+	return Vec2{
+		X: tinymath.Cos(a.a),
+		Y: -tinymath.Sin(a.a),
+	}
+}
+
 func (a Angle) Neg() Angle {
 	a.a = -a.a
 	return a
@@ -269,7 +284,7 @@ type RGB struct {
 	B uint8
 }
 
-func NewRGB(r uint8, g uint8, b uint8) RGB {
+func NewRGB(r, g, b uint8) RGB {
 	return RGB{R: r, G: g, B: b}
 }
 

--- a/firefly/input.go
+++ b/firefly/input.go
@@ -41,7 +41,18 @@ func (p Pad) Radius() float32 {
 	return tinymath.Sqrt(float32(r))
 }
 
+// Radius returns the squared distance from the pad center to the touch point,
+// which is simpler to calculate, and guarantees that the return value is an integer.
+func (p Pad) RadiusSquared() int {
+	return p.X*p.X + p.Y*p.Y
+}
+
 // The angle of the [polar coordinate] of the touch point.
+//
+//   - (Pad{X: 1, Y: 0}).Azimuth() == [Degrees](0)
+//   - (Pad{X: 0, Y: 1}).Azimuth() == [Degrees](90)
+//   - (Pad{X: -1, Y: 0}).Azimuth() == [Degrees](180)
+//   - (Pad{X: 0, Y: -1}).Azimuth() == [Degrees](270)
 //
 // [polar coordinate]: https://en.wikipedia.org/wiki/Polar_coordinate_system
 func (p Pad) Azimuth() Angle {

--- a/firefly/vec2.go
+++ b/firefly/vec2.go
@@ -1,0 +1,116 @@
+package firefly
+
+import (
+	"math"
+
+	"github.com/orsinium-labs/tinymath"
+)
+
+const cmp_epsilon = 0.00001
+
+// Vec2 is a utility class for dealing with float-based positions.
+type Vec2 struct {
+	X float32
+	Y float32
+}
+
+// V is a shortcut for creating a [Vec2]
+func V(x, y float32) Vec2 {
+	return Vec2{X: x, Y: y}
+}
+
+// Convert a Vec2 to a [Point].
+// The X and Y floats are truncated, meaning the floored value of positive numbers
+// and the ceiling value of negative values.
+func (v Vec2) Point() Point {
+	return Point{X: int(v.X), Y: int(v.Y)}
+}
+
+// Round returns a new Vec2 with both X and Y rounded to the nearest integer.
+func (v Vec2) Round() Vec2 {
+	return Vec2{X: tinymath.Round(v.X), Y: tinymath.Round(v.Y)}
+}
+
+func (v Vec2) Abs() Vec2 {
+	return Vec2{X: tinymath.Abs(v.X), Y: tinymath.Abs(v.Y)}
+}
+
+func (v Vec2) Add(rhs Vec2) Vec2 {
+	return Vec2{X: v.X + rhs.X, Y: v.Y + rhs.Y}
+}
+
+func (v Vec2) Sub(rhs Vec2) Vec2 {
+	return Vec2{X: v.X - rhs.X, Y: v.Y - rhs.Y}
+}
+
+func (v Vec2) Negate() Vec2 {
+	return Vec2{X: -v.X, Y: -v.Y}
+}
+
+// ComponentMin returns a Vec2 with both X and Y to their minimum in the two given Vec2s.
+func (p Vec2) ComponentMin(r Vec2) Vec2 {
+	if r.X < p.X {
+		p.X = r.X
+	}
+	if r.Y < p.Y {
+		p.Y = r.Y
+	}
+	return p
+}
+
+// ComponentMax returns a Vec2 with both X and Y to their maximum in the two given Vec2s.
+func (p Vec2) ComponentMax(r Vec2) Vec2 {
+	if r.X > p.X {
+		p.X = r.X
+	}
+	if r.Y > p.Y {
+		p.Y = r.Y
+	}
+	return p
+}
+
+// Check if the Vec2 is within the screen boundaries.
+func (p Vec2) InBounds() bool {
+	return p.X >= 0 && p.Y >= 0 && p.X < Width && p.Y < Height
+}
+
+// Scale returns a new Vec2 where both the X and Y value are individually
+// multiplied by the scalar factor.
+func (v Vec2) Scale(factor float32) Vec2 {
+	return Vec2{X: v.X * factor, Y: v.Y * factor}
+}
+
+// Radius returns the vector length (aka magnitude).
+func (v Vec2) Radius() float32 {
+	return tinymath.Sqrt(v.X*v.X + v.Y*v.Y)
+}
+
+// Radius returns the squared vector length (aka squared magnitude),
+// which is simpler to calculate.
+func (v Vec2) RadiusSquared() float32 {
+	return v.X*v.X + v.Y*v.Y
+}
+
+// Azimuth returns the angle of the [polar coordinate] of the vector.
+//
+//   - [V](1, 0).Azimuth() == [Degrees](0)
+//   - [V](0, 1).Azimuth() == [Degrees](90)
+//   - [V](-1, 0).Azimuth() == [Degrees](180)
+//   - [V](0, -1).Azimuth() == [Degrees](270)
+func (v Vec2) Azimuth() Angle {
+	r := math.Pi / 2. * tinymath.Atan2Norm(v.Y, v.X)
+	return Radians(r)
+}
+
+// MoveTowards returns a vector that has moved towards "to" by the "delta"
+// amount, but will not go past "to".
+// Use negative "delta" value to move away.
+func (v Vec2) MoveTowards(to Vec2, delta float32) Vec2 {
+	vd := to.Sub(v)
+	dist := vd.Radius()
+	if dist <= delta || dist < cmp_epsilon {
+		return to
+	} else {
+		return v.Add(vd.Scale(delta / dist))
+	}
+}


### PR DESCRIPTION
Adds a `Vec2` utility type that is a basic `Point`, but `float32`

The power of having this in the SDK is that it gives nicer integration, such as `Point.Vec2`
