### PR TITLE
Fix `Image.Pixels()` calculation

### DIFF
--- a/firefly/graphics.go
+++ b/firefly/graphics.go
@@ -456,7 +456,9 @@ func (i Image) SetTransparency(c Color) {
 
 // The number of pixels the image has.
 func (i Image) Pixels() int {
-	return len(i.raw) * 8 / int(i.BPP())
+	bpp := int(i.BPP())
+	headerSize := 5 + (1 << (bpp - 1))
+	return (len(i.raw) - headerSize) * 8 / bpp
 }
 
 // The image width in pixels.

--- a/firefly/graphics_test.go
+++ b/firefly/graphics_test.go
@@ -47,7 +47,7 @@ var image4BPP = []byte{
 	0xcd, 0xef, // row 4
 }
 
-func TestExtImage_GetPixel(t *testing.T) {
+func TestImage_GetPixel(t *testing.T) {
 	t.Parallel()
 	P := firefly.P
 	tests := []struct {
@@ -94,6 +94,30 @@ func TestExtImage_GetPixel(t *testing.T) {
 			got := image.GetPixel(test.pixel)
 			if got != test.want {
 				t.Errorf("pixel: {%d, %d}, want %s, but got %s", test.pixel.X, test.pixel.Y, test.want, got)
+			}
+		})
+	}
+}
+
+func TestImagePixels(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		raw  []byte
+		want int
+	}{
+		{name: "1 BPP", raw: image1BPP, want: 16},
+		{name: "2 BPP", raw: image2BPP, want: 16},
+		{name: "4 BPP", raw: image4BPP, want: 16},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			image := firefly.File{test.raw}.Image()
+			got := image.Pixels()
+			if got != test.want {
+				t.Errorf("want %d, but got %d", test.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes the `Image.Pixels()` method.

It gave the wrong result. Here's the test results before the fix:

```console
$ go test ./...
--- FAIL: TestImagePixels (0.00s)
    --- FAIL: TestImagePixels/1_BPP (0.00s)
        graphics_test.go:120: want 16, but got 64
    --- FAIL: TestImagePixels/2_BPP (0.00s)
        graphics_test.go:120: want 16, but got 44
    --- FAIL: TestImagePixels/4_BPP (0.00s)
        graphics_test.go:120: want 16, but got 42
FAIL
FAIL    github.com/firefly-zero/firefly-go/firefly      0.006s
?       github.com/firefly-zero/firefly-go/firefly/audio        [no test files]
?       github.com/firefly-zero/firefly-go/firefly/shapes       [no test files]
?       github.com/firefly-zero/firefly-go/firefly/sudo [no test files]
FAIL
```
